### PR TITLE
タスク記録機能の実装（記録ページ）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'pry-rails'
 gem 'active_hash'
 gem 'devise'
+gem "chartkick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
+    chartkick (3.4.2)
     childprocess (3.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -225,6 +226,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  chartkick
   devise
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/stylesheets/user/record.css
+++ b/app/assets/stylesheets/user/record.css
@@ -1,0 +1,59 @@
+/* 記録画面 */
+.records {
+  width: 80vw;
+  height: 703px;
+  margin: 0 auto;
+  margin-top: 100px;
+  display: flex;
+  flex-direction: column;
+  overflow: scroll;
+}
+
+/* タスク数・達成数・達成時間計 */
+.record-contents {
+  width: 70vw;
+  height: 150px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.record-content {
+  width: 20vw;
+  height: 100px;
+  margin-top: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  border: 2px solid #cccccc;
+  border-radius: 10px;
+}
+
+.record-content-title {
+  width: 20VW;
+  height: 40px;
+  font-size: 18px;
+  text-align: center;
+  line-height: 40px;
+  border-bottom: 2px solid #cccccc;
+}
+
+.record-content-num {
+  width: 20VW;
+  height: 60px;
+  font-size: 20px;
+  text-align: center;
+  line-height: 60px;
+}
+
+.record-content-num > span {
+  font-size: 15px;
+  color: #cccccc;
+}
+
+.record-achivement-graph {
+  margin: 0 auto;
+  margin-top: 120px;
+}

--- a/app/assets/stylesheets/user/record.css
+++ b/app/assets/stylesheets/user/record.css
@@ -55,5 +55,17 @@
 
 .record-achivement-graph {
   margin: 0 auto;
-  margin-top: 120px;
+  padding: 20px;
+  margin-top: 110px;
+  border: 2px solid #cccccc;
+  border-radius: 10px;
+}
+
+.record-achivement-graph-title {
+  width: 20vw;
+  margin: 0 auto;
+  margin-bottom: 10px;
+  font-size: 18px;
+  text-align: center;
+  border-bottom: 2px solid #cccccc;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,15 @@
 class UsersController < ApplicationController
-  before_action :user, only: [:show, :task, :following, :followers]
-  before_action :tweets, only: [:show, :task]
+  before_action :set_user
+  before_action :tweets, only: [:show, :task, :record]
   before_action :today, only: [:task]
 
   def show
   end
 
   def task
+  end
+
+  def record
   end
 
   def following
@@ -19,12 +22,12 @@ class UsersController < ApplicationController
 
   private
 
-  def user
+  def set_user
     @user = User.find(params[:id])
   end
 
   def tweets
-    @tweets = user.tweets
+    @tweets = @user.tweets
   end
 
   def today

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 class UsersController < ApplicationController
   before_action :set_user
   before_action :tweets, only: [:show, :task, :record]
-  before_action :today, only: [:task]
+  before_action :today, only: [:task, :record]
+  before_action :week, only: [:record]
+  before_action :time_sum, only: [:record]
 
   def show
   end
@@ -10,6 +12,7 @@ class UsersController < ApplicationController
   end
 
   def record
+    @week_achievement = { @six_days_ago => @six_day_achievement, @five_days_ago => @five_day_achievement, @four_days_ago => @four_day_achievement, @three_days_ago => @three_day_achievement,@two_days_ago => @two_day_achievement, @one_days_ago => @one_day_achievement, @today => @today_achievement, }
   end
 
   def following
@@ -27,7 +30,7 @@ class UsersController < ApplicationController
   end
 
   def tweets
-    @tweets = @user.tweets
+    @tweets = @user.tweets.order('created_at DESC')
   end
 
   def today
@@ -35,7 +38,112 @@ class UsersController < ApplicationController
     month = today.month
     day = today.day
     @today = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    today_achievement = []
+    @achievements.each do |achievement|
+      if @today == achievement.updated_at.strftime("%m月%-d日")
+        today_achievement << achievement 
+      end
+      @today_achievement = today_achievement.count
+    end
   end
 
+  def week
+    today = Time.current
+    yesterday = today.yesterday
+    month = yesterday.month
+    day = yesterday.day
+    @one_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    one_day_achievement = []
+    @achievements.each do |achievement|
+      if @one_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        one_day_achievement << achievement 
+      end
+      @one_day_achievement = one_day_achievement.count
+    end
+
+    two_day = today.ago(2.days)
+    month = two_day.month
+    day = two_day.day
+    @two_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    two_day_achievement = []
+    @achievements.each do |achievement|
+      if @two_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        two_day_achievement << achievement 
+      end
+      @two_day_achievement = two_day_achievement.count
+    end
+
+    three_day = today.ago(3.days)
+    month = three_day.month
+    day = three_day.day
+    @three_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    three_day_achievement = []
+    @achievements.each do |achievement|
+      if @three_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        three_day_achievement << achievement 
+      end
+      @three_day_achievement = three_day_achievement.count
+    end
+
+    four_day = today.ago(4.days)
+    month = four_day.month
+    day = four_day.day
+    @four_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    four_day_achievement = []
+    @achievements.each do |achievement|
+      if @four_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        four_day_achievement << achievement 
+      end
+      @four_day_achievement = four_day_achievement.count
+    end
+
+    five_day = today.ago(5.days)
+    month = five_day.month
+    day = five_day.day
+    @five_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    five_day_achievement = []
+    @achievements.each do |achievement|
+      if @five_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        five_day_achievement << achievement 
+      end
+      @five_day_achievement = five_day_achievement.count
+    end
+
+    six_day = today.ago(6.days)
+    month = six_day.month
+    day = six_day.day
+    @six_days_ago = "#{month}月#{day}日"
+    @achievements = Achievement.where(user_id: params[:id])
+    six_day_achievement = []
+    @achievements.each do |achievement|
+      if @six_days_ago == achievement.updated_at.strftime("%m月%-d日")
+        six_day_achievement << achievement 
+      end
+      @six_day_achievement =six_day_achievement.count
+    end
+  end
+
+  def time_sum
+    @achievements = Achievement.where(user_id: params[:id])
+    hour_array = []
+    minute_array = []
+    @achievements.each do |achievement|
+      hour_sum = achievement.tweet.end_hour.name.to_i - achievement.tweet.start_hour.name.to_i
+      minute_sum = achievement.tweet.end_minute.name.to_i + achievement.tweet.start_minute.name.to_i
+      hour_array << hour_sum
+      minute_array << minute_sum
+    end
+    hours_array = hour_array.sum
+    m_array = minute_array.sum
+    minute_array = m_array / 60
+    sum = hours_array + minute_array
+    @time_sum = sum.floor
+  end
 
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,8 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("jquery")
+require("chartkick")
+require("chart.js")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.already_favorited?(tweet) %>
+<% if user_signed_in? && current_user.already_favorited?(tweet) %>
   <%= link_to tweet_favorites_path(tweet), method: :delete, remote: true do %>
     <i class="fas fa-heart"> いいね
     <span class="favorite-num"><%= tweet.favorites.count %></span></i>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <% if user_signed_in? %>
       <%= link_to "ホーム", root_path, class: "footer-title-item" %>
       <%= link_to "朝活タスク", task_user_path(current_user.id), method: :get, class: "footer-title-item" %>
-      <%= link_to "レポート", root_path, class: "footer-title-item" %>
+      <%= link_to "レポート", record_user_path(current_user.id), class: "footer-title-item" %>
     <% else %>
       <%= link_to "ホーム", root_path, class: "footer-title-item" %>
       <%= link_to "朝活タスク", root_path, class: "footer-title-item" %>

--- a/app/views/users/record.html.erb
+++ b/app/views/users/record.html.erb
@@ -49,7 +49,7 @@
   
   <%# 達成数のグラフ %>
   <div class="record-achivement-graph">
-    1週間の達成数
+    <div class="record-achivement-graph-title">1週間の達成数</div>
     <%= column_chart @week_achievement, width: "70vw", max: 10, discrete: true  %>
   </div>
 

--- a/app/views/users/record.html.erb
+++ b/app/views/users/record.html.erb
@@ -1,0 +1,58 @@
+<header>
+  <div class="header-back header-item">
+  </div>
+
+  <div class="header-title header-item">
+    <p class="header-title-item">記録</p>
+  </div>
+
+  <div class="header-content header-item">
+  </div>
+</header>
+
+<div class="records">
+
+  <%# タスク数・達成数・達成時間計 %>
+  <div class="record-contents">
+
+    <%# タスク数 %>
+    <div class="record-content">
+      <div class="record-content-title">
+        タスク数
+      </div>
+      <div class="record-content-num">
+        <%= @tweets.count %>
+      </div>
+    </div>
+
+    <%# 達成数 %>
+    <div class="record-content">
+      <div class="record-content-title">
+        達成数
+      </div>
+      <div class="record-content-num">
+        <%= @time_sum %>
+      </div>
+    </div>
+
+    <%# 達成時間計 %>
+    <div class="record-content">
+      <div class="record-content-title">
+        達成時間計
+      </div>
+      <div class="record-content-num">
+        <%= @user.achievements.count %><span> h</span>
+      </div>
+    </div>
+
+  </div>
+  
+  <%# 達成数のグラフ %>
+  <div class="record-achivement-graph">
+    1週間の達成数
+    <%= column_chart @week_achievement, width: "70vw", max: 10, discrete: true  %>
+  </div>
+
+</div>
+
+<%= render "shared/footer" %>

--- a/app/views/users/task.html.erb
+++ b/app/views/users/task.html.erb
@@ -1,6 +1,5 @@
 <header>　　
   <div class="header-back header-item">
-    <%= link_to "＜", :back, class: "header-back-btn" %>
   </div>
 
   <div class="header-title header-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   # ユーザー機能に関するルーティング
   resources :users, only: :show do
     member do
-      get :task, :following, :followers
+      get :task, :record, :following, :followers
     end
   end
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "4.3.0",
     "bootstrap": "^4.5.3",
+    "chart.js": "^2.9.4",
+    "chartkick": "^3.2.1",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,6 +1821,34 @@ chalk@^2.0, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chart.js@^2.9.4:
+  version "2.9.4"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-2.9.4.tgz#0827f9563faffb2dc5c06562f8eb10337d5b9684"
+  integrity sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==
+  dependencies:
+    chartjs-color "^2.1.0"
+    moment "^2.10.2"
+
+chartjs-color-string@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"
+  integrity sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==
+  dependencies:
+    color-name "^1.0.0"
+
+chartjs-color@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chartjs-color/-/chartjs-color-2.4.1.tgz#6118bba202fe1ea79dd7f7c0f9da93467296c3b0"
+  integrity sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==
+  dependencies:
+    chartjs-color-string "^0.6.0"
+    color-convert "^1.9.3"
+
+chartkick@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/chartkick/-/chartkick-3.2.1.tgz#a80c2005ae353c5ae011d0a756b6f592fc8fc7a9"
+  integrity sha512-zV0kUeZNqrX28AmPt10QEDXHKadbVFOTAFkCMyJifHzGFkKzGCDXxVR8orZ0fC1HbePzRn5w6kLCOVxDQbMUCg==
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -1935,7 +1963,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0, color-convert@^1.9.1:
+color-convert@^1.9.0, color-convert@^1.9.1, color-convert@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -4550,6 +4578,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment@^2.10.2:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
# What
タスクの記録機能の導入

# Why
タスク数・タスク達成数・達成時間計を記録ページでログインユーザーが確認できるようにするため。

# 内容
・記録ページの作成と遷移先の設定
・タスク数の表示（タスク作成数をカウント）
・タスク達成数の表示（達成しているタスクを基準にカウント）
・達成合計時間の表示
（達成しているタスクを基準に1つ1つのタスクの時間を算出し合計）
・1週間の達成数のグラフの表示

# 確認方法
・記録ページに遷移できるか
・タスク数・達成数・達成時間は正しく表示されている。
・1週間の達成数のグラフは正しく表示されている。
・記録ページからホーム画面・朝活タスク画面に遷移できる。
・見た目は最低限整っている。
・ページに大きさで見た目が対応できている。