### PR TITLE
戻るボタンの遷移先修正

### DIFF
--- a/app/views/users/followers.html.erb
+++ b/app/views/users/followers.html.erb
@@ -1,6 +1,6 @@
-<header>　　
+<header>
   <div class="header-back header-item">
-    <%= link_to "＜", 'javascript:history.back()', class: "header-back-btn" %>
+    <%= link_to "＜", user_path(@user.id), class: "header-back-btn" %>
   </div>
 
   <div class="header-title header-item">

--- a/app/views/users/following.html.erb
+++ b/app/views/users/following.html.erb
@@ -1,6 +1,6 @@
-<header>　　
+<header>
   <div class="header-back header-item">
-    <%= link_to "＜", 'javascript:history.back()', class: "header-back-btn" %>
+    <%= link_to "＜", user_path(@user.id), class: "header-back-btn" %>
   </div>
 
   <div class="header-title header-item">


### PR DESCRIPTION
# What
フォロー機能の修正

# Why
フォローページ及びフォロワーページの戻るボタンを遷移先を修正するため

# 内容
・遷移先の修正

# 確認方法
・フォローボタンを押してフォローした後にフォロページまたはフォロワーページに遷移し戻るボタンを押したときにフォローしたままの状態になっているか。（修正前はルートをひとつ戻る実装をしていたためマイページに戻った際にフォローが解除されてしまっていた。）